### PR TITLE
Add support for rich logging features

### DIFF
--- a/src/shell.me/ShellMe.CommandLine.Tests/CommandTests.cs
+++ b/src/shell.me/ShellMe.CommandLine.Tests/CommandTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using ShellMe.CommandLine.CommandHandling;
@@ -29,6 +30,19 @@ namespace ShellMe.CommandLine.Tests
 
             var commandLoop = new CommandLoop(console, commandFactory);
             Assert.DoesNotThrow(() => commandLoop.Start(new[] { "--test" }));
+        }
+
+        [Test]
+        public void MaliciousCommandWontTakeShellMeDown()
+        {
+            var console = new TestConsole(new List<string>(){"exit"});
+            var commandFactory = new CommandFactory(new ICommand[] { new MaliciousCommand() });
+
+            var commandLoop = new CommandLoop(console, commandFactory);
+            commandLoop.Start(new[] {"malicious", " --value=4", "--non-interactive"});
+            Assert.AreEqual(2, console.OutputQueue.Count);
+            Assert.True(console.OutputQueue[0].StartsWith("Unexpected error happended while proceeding the command: Malicious"));
+            
         }
 
         [Test]
@@ -148,11 +162,7 @@ namespace ShellMe.CommandLine.Tests
             var commandFactory = new CommandFactory(new[] { new ExceptionCommand() });
             var commandLoop = new CommandLoop(console, commandFactory);
             commandLoop.Start(new[] { "RaiseException", "--nonInteractive" });
-
-            Assert.AreEqual("Unexpected error happended while proceeding the command: RaiseException", console.OutputQueue[0]);
-            Assert.AreEqual("Exception: Foo", console.OutputQueue[1]);
-            Assert.IsTrue(console.OutputQueue[2].StartsWith("Stacktrace:"));
-            Assert.AreEqual("Exception: Bar", console.OutputQueue[3]);
+            Assert.IsTrue(console.OutputQueue[0].StartsWith("Unexpected error happended while proceeding the command: RaiseException"));
         }
 
         [Test]

--- a/src/shell.me/ShellMe.CommandLine/CommandHandling/BaseCommand.cs
+++ b/src/shell.me/ShellMe.CommandLine/CommandHandling/BaseCommand.cs
@@ -1,16 +1,19 @@
 ﻿namespace ShellMe.CommandLine.CommandHandling
 {
-    public abstract class BaseCommand : ICommand
+    public abstract class BaseCommand : ICommand, ITraceableCommand
     {
         protected BaseCommand()
         {
             AllowParallel = true;
         }
 
-        public IConsole Console { get; set; }
+        public ITraceConsole Console { get; set; }
         public bool NonInteractive { get; set; }
-        public bool Verbose { get; set; }
         public bool AllowParallel { get; set; }
+        public bool Verbose { get; set; }
+        public string WriteFile { get; set; }
+        public bool WriteEventLog { get; set; }
+
         public abstract string Name { get; }
         public abstract void Run();
     }

--- a/src/shell.me/ShellMe.CommandLine/CommandHandling/ICommand.cs
+++ b/src/shell.me/ShellMe.CommandLine/CommandHandling/ICommand.cs
@@ -2,7 +2,7 @@
 {
     public interface ICommand
     {
-        IConsole Console { get; set; }
+        ITraceConsole Console { get; set; }
 
         bool NonInteractive { get; set; }
 

--- a/src/shell.me/ShellMe.CommandLine/CommandHandling/ITraceableCommand.cs
+++ b/src/shell.me/ShellMe.CommandLine/CommandHandling/ITraceableCommand.cs
@@ -1,0 +1,8 @@
+﻿namespace ShellMe.CommandLine.CommandHandling
+{
+    public interface ITraceableCommand
+    {
+        string WriteFile { get; set; }
+        bool WriteEventLog { get; set; }
+    }
+}

--- a/src/shell.me/ShellMe.CommandLine/ITraceConsole.cs
+++ b/src/shell.me/ShellMe.CommandLine/ITraceConsole.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+
+namespace ShellMe.CommandLine
+{
+    public interface ITraceConsole : IConsole
+    {
+        void TraceEvent(TraceEventType traceEventType, int code, string message);
+    }
+}

--- a/src/shell.me/ShellMe.CommandLine/ShellMe.CommandLine.csproj
+++ b/src/shell.me/ShellMe.CommandLine/ShellMe.CommandLine.csproj
@@ -53,26 +53,29 @@
     <Compile Include="CommandHandling\CommandPropertyWalker.cs" />
     <Compile Include="ExceptionWalker.cs" />
     <Compile Include="IConsole.cs" />
+    <Compile Include="CommandHandling\ITraceableCommand.cs" />
+    <Compile Include="ITraceConsole.cs" />
     <Compile Include="Locking\FileBasedLockingService.cs" />
     <Compile Include="Locking\ILockingService.cs" />
     <Compile Include="NativeConsoleWrapper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TraceConsole.cs" />
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>
   -->
-    <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release' ">
-        <CreateItem Condition="'%(Extension)'=='.dll'" Include="@(ReferenceCopyLocalPaths)">
-            <Output TaskParameter="Include" ItemName="IlmergeAssemblies" />
-        </CreateItem>
-        <Exec Command="&quot;$(ProjectDir)..\..\..\tools\IlMerge\Ilmerge.exe&quot; /targetplatform:&quot;v4,C:\Windows\Microsoft.NET\Framework64\v4.0.30319&quot; /ndebug /out:@(MainAssembly) &quot;@(IntermediateAssembly)&quot; @(IlmergeAssemblies->'&quot;%(FullPath)&quot;', ' ')" />
-        <Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
-    </Target>
+  <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release' ">
+    <CreateItem Condition="'%(Extension)'=='.dll'" Include="@(ReferenceCopyLocalPaths)">
+      <Output TaskParameter="Include" ItemName="IlmergeAssemblies" />
+    </CreateItem>
+    <Exec Command="&quot;$(ProjectDir)..\..\..\tools\IlMerge\Ilmerge.exe&quot; /targetplatform:&quot;v4,C:\Windows\Microsoft.NET\Framework64\v4.0.30319&quot; /ndebug /out:@(MainAssembly) &quot;@(IntermediateAssembly)&quot; @(IlmergeAssemblies->'&quot;%(FullPath)&quot;', ' ')" />
+    <Delete Files="@(ReferenceCopyLocalPaths->'$(OutDir)%(DestinationSubDirectory)%(Filename)%(Extension)')" />
+  </Target>
 </Project>

--- a/src/shell.me/ShellMe.CommandLine/TraceConsole.cs
+++ b/src/shell.me/ShellMe.CommandLine/TraceConsole.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using ShellMe.CommandLine.CommandHandling;
+
+namespace ShellMe.CommandLine
+{
+    class TraceConsole : ITraceConsole
+    { 
+        public TraceConsole(IConsole console, ICommand command)
+        {
+            Console = console;
+            Command = command;
+
+            TraceableCommand = command as ITraceableCommand;
+
+            if (TraceableCommand != null)
+            {
+                Trace.AutoFlush = true;
+                TraceSource = new TraceSource(command.Name)
+                                  {
+                                      Switch = new SourceSwitch(Command.Name)
+                                                   {
+                                                       Level = SourceLevels.All
+                                                   }
+                                  };
+
+
+                if (!string.IsNullOrEmpty(TraceableCommand.WriteFile))
+                {
+                    TraceSource.Listeners.Add(new TextWriterTraceListener(TraceableCommand.WriteFile));
+                }
+                if (TraceableCommand.WriteEventLog)
+                {
+                    TraceSource.Listeners.Add(new EventLogTraceListener(Command.Name));
+                }
+            }
+        }
+
+        protected ITraceableCommand TraceableCommand { get; private set; }
+
+        protected ICommand Command { get; set; }
+
+        protected TraceSource TraceSource { get; private set; }
+
+        protected IConsole Console { get; private set; }
+
+        public void WriteLine(string line)
+        {
+            Console.WriteLine(line);
+
+            if(TraceSource != null)
+            {
+                TraceSource.TraceInformation(line);
+            }
+        }
+
+        public string ReadLine()
+        {
+            return Console.ReadLine();
+        }
+
+        public ConsoleColor ForegroundColor
+        {
+            get { return Console.ForegroundColor; }
+            set { Console.ForegroundColor = value; }
+        }
+
+        public void ResetColor()
+        {
+            Console.ResetColor();
+        }
+
+        public void TraceEvent(TraceEventType traceEventType, int code, string message)
+        {
+            Console.WriteLine(message);
+
+            if(TraceableCommand != null)
+                TraceSource.TraceEvent(traceEventType, code, message);
+        }
+    }
+}

--- a/src/shell.me/ShellMe.Testing/MaliciousCommand.cs
+++ b/src/shell.me/ShellMe.Testing/MaliciousCommand.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using ShellMe.CommandLine.CommandHandling;
+
+namespace ShellMe.Testing
+{
+    public class MaliciousCommand : BaseCommand
+    {
+        public override string Name
+        {
+            get { return "Malicious"; }
+        }
+
+        public override void Run()
+        {
+            Console.WriteLine("Should not see me");
+        }
+
+        public int Value
+        {
+            get { return 0; }
+            set {throw new Exception("Should not happen");}
+        }
+    }
+}

--- a/src/shell.me/ShellMe.Testing/ShellMe.Testing.csproj
+++ b/src/shell.me/ShellMe.Testing/ShellMe.Testing.csproj
@@ -44,6 +44,7 @@
     <Compile Include="ExceptionCommand.cs" />
     <Compile Include="IntPropertyCommand.cs" />
     <Compile Include="EnumerableIntCommand.cs" />
+    <Compile Include="MaliciousCommand.cs" />
     <Compile Include="LongRunningCommand.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestCommand.cs" />


### PR DESCRIPTION
Logging is a first class concern. We want to use shell.me to drop a lot of services that currently rely on the System.Diagnostics logging capabilities. While it is pretty easy to bootstrap System.Diagnostic in each command on your own, there are some things that we could help to make life easier:
1. The configuration file should be optional. The traditional way to configure logging in System.Diagnostic is through the app.config file. For shell.me I would like to see that optional and default to a command line based approach instead!
2. Something like: `foo --log={ Listener :[{Name:File, Path:C:\test},{Name:Event}] }`

Log would be a property on the command of type `LoggingConfiguration` so we would just write a custom TypeProvider to make that actually work. We still need to figure out what's the best approach to configure all the different possible TraceListeners for us then. We need to put more thought into that.

Here is how to configure Tracing programatically: http://msdn.microsoft.com/en-us/library/sk36c28t.aspx
